### PR TITLE
Fix `subPath` for mount of `naa-vre-user-data` bucket

### DIFF
--- a/values/values.yaml
+++ b/values/values.yaml
@@ -102,7 +102,7 @@ jupyterhub:
             mountPath: /home/jovyan/naa-vre-public
           - name: naa-vre-user-data
             mountPath: /home/jovyan/naa-vre-user-data/
-            subPath: '{username}'
+            subPath: '{unescaped_username}'
 
 
 k8sSecretCreator:


### PR DESCRIPTION
Replace `username` with `unescaped_username`, to match `jwt:preferred_username` used to determine the user's prefix in the bucket. 

Related to https://github.com/NaaVRE/NaaVRE-helm/pull/15